### PR TITLE
初回ビルドエラー修正

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -48,6 +48,7 @@ if "%GIT_USEREMAIL%" == "" (
 echo.
 
 echo 4. Building...
+mvn clean
 if exist "%~dp0keystore" (
   call mvn clean compile install --settings ./.mvn/local-settings.xml
 ) else (

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,7 @@ fi
 printf "\n"
 
 printf "4. Building...\n"
+mvn clean
 if [ -e ./keystore ]; then
     mvn clean compile install --settings ./.mvn/local-settings.xml
 else


### PR DESCRIPTION
ローカルリポジトリが存在しない状態で初回ビルドを行った際に、必要なライブラリがローカルリポジトリにインストールされずにビルドエラーとなる問題を修正