### PR TITLE
oshi 5.1.2 -> 5.7.2

### DIFF
--- a/src/NoraCommon/pom.xml
+++ b/src/NoraCommon/pom.xml
@@ -192,7 +192,7 @@
 		<dependency>
 			<groupId>com.github.oshi</groupId>
 			<artifactId>oshi-core</artifactId>
-			<version>5.1.2</version>
+			<version>5.7.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
issue向けな話題かもしれませんが、軽微な修正なのでいきなりPRで失礼致します。
[oshi](https://github.com/oshi/oshi/) 5.1.2が使われているようですが、現時点の最新版(5.7.2)ではAIX/OpenBSD対応が入っているので更新してみてはどうか…という御提案です。
こちらでは更新してもビルドエラーが出ないこと、得られたjarファイルをOpenBSD-6.9上で動作させてもunsupported OSの表示が出なくなったこと程度しか確認できていないので、テストが必要です。
[Guide to upgrading from OSHI 4.x to 5.x](https://github.com/oshi/oshi/blob/master/UPGRADING.md)を見るに、oshi 4.7.0〜4.8.2との互換性を持つ最終版が5.1.2のようですので、アップデートによる意図しない動作/悪影響を懸念しています。
問題が無いようでしたら、取り込んでいただければ幸いです。